### PR TITLE
Fixing upper interval border case in gradient

### DIFF
--- a/src/CubicSplines.jl
+++ b/src/CubicSplines.jl
@@ -213,6 +213,7 @@ function gradient(spline::CubicSpline, x::Real, n::Integer)
     # Value sits on upper interval border
     if x == spline.xs[end]
         idx = length(spline.xs)-1
+        coeff = []
 
     # Find the corresponding interval
     else


### PR DESCRIPTION
I believe this should fix the error generated by the edge case in which the value sits on the upper interval border, as `coeffs` is not instantiated in the corresponding branch.