### PR TITLE
fixed upper border case of gradient function

### DIFF
--- a/src/CubicSplines.jl
+++ b/src/CubicSplines.jl
@@ -219,29 +219,29 @@ function gradient(spline::CubicSpline, x::Real, n::Integer)
 
         # Find the interval index
         idx = _binary_search_interval(spline.xs, x)
+    end
 
-        # Extrapolation to the "left"
-        if idx == 0
-            if spline.extrapl === nothing
-                throw("x too small ($x < $(spline.xs[1]))")
-            else
-                coeff = spline.extrapl
-                x_ref = spline.xs[1]
-            end
-
-        # Extrapolation to the "right"
-        elseif idx == length(spline.xs)
-            if spline.extrapr === nothing
-                throw("x too big ($x > $(spline.xs[end]))")
-            else
-                coeff = spline.extrapr
-                x_ref = spline.xs[end]
-            end
+    # Extrapolation to the "left"
+    if idx == 0
+        if spline.extrapl === nothing
+            throw("x too small ($x < $(spline.xs[1]))")
         else
-            coeff = spline.ps[idx,:]
-            x_ref = spline.xs[idx]
-
+            coeff = spline.extrapl
+            x_ref = spline.xs[1]
         end
+
+    # Extrapolation to the "right"
+    elseif idx == length(spline.xs)
+        if spline.extrapr === nothing
+            throw("x too big ($x > $(spline.xs[end]))")
+        else
+            coeff = spline.extrapr
+            x_ref = spline.xs[end]
+        end
+    else
+        coeff = spline.ps[idx,:]
+        x_ref = spline.xs[idx]
+
     end
 
     # Calculate the coefficients of degree n


### PR DESCRIPTION
Thanks for making a good library for interpolation.
I used this and noticed that when using the gradient function for just the upper border of the interpolation case, this function makes the error `UndefVarError: coeff not defined`.
This seems because the variable `coeff` was not initialized in that case, so I change the code a little to fix this.
If there is no problem, I would be happy if you accept this PR.